### PR TITLE
force load to speed up

### DIFF
--- a/mom6/data_structure/data_preprocessing/batch_preprocess_reforecast_nep_dmitry.py
+++ b/mom6/data_structure/data_preprocessing/batch_preprocess_reforecast_nep_dmitry.py
@@ -146,7 +146,7 @@ def cefi_preprocess(dict_setting:dict):
             # get file group
             list_ds = []
             for ens in range(1,10+1):
-                list_ds.append(xr.open_dataset(f"{year_path}/{process_file_tag}-e{ens:02d}.nc",chunks='auto'))
+                list_ds.append(xr.open_dataset(f"{year_path}/{process_file_tag}-e{ens:02d}.nc").load())
             ds = xr.concat(list_ds,dim='member')
             ds['time'] = np.arange(0,12)
             ds['member'] = np.arange(1,11)


### PR DESCRIPTION
This pull request makes a small but important change to the data loading process in the `cefi_preprocess` function. The change ensures that datasets are fully loaded into memory instead of using lazy loading with dask chunks, which can help avoid issues with delayed computation and improve data reliability during preprocessing.

* Changed the way datasets are loaded in the `cefi_preprocess` function in `batch_preprocess_reforecast_nep_dmitry.py` by replacing dask chunking with explicit `.load()` to force eager loading of data.